### PR TITLE
fix: remove background element from screen reader focus in popovers

### DIFF
--- a/src/BasePopover.tsx
+++ b/src/BasePopover.tsx
@@ -495,7 +495,7 @@ export default class BasePopover extends Component<BasePopoverProps, BasePopover
         />
         <Animated.View pointerEvents="box-none" style={containerStyle} onAccessibilityEscape={this.props.onRequestClose}>
           {this.props.showBackground !== false && (
-            <TouchableWithoutFeedback onPress={this.props.onRequestClose} accessibilityRole="button" accessible>
+            <TouchableWithoutFeedback onPress={this.props.onRequestClose} accessible={false} importantForAccessibility="no-hide-descendants">
               <Animated.View style={backgroundStyle} />
             </TouchableWithoutFeedback>
           )}


### PR DESCRIPTION
When a popover opens, screen readers were incorrectly focusing on the background overlay instead of the modal content. As a result, users heard generic "button" or "screenshot" announcements rather than the intended popover content.

Root cause:
The background’s TouchableWithoutFeedback had `accessibilityRole="button"` and `accessible={true}`, which made it focusable and intercepted screen reader focus.

Solution:
- Remove `accessibilityRole="button"` from the background
- Set `accessible={false}` to prevent it from being announced
- Add `importantForAccessibility="no-hide-descendants"` so screen readers skip the background entirely

Result:
Screen readers on iOS and Android now correctly announce the popover’s content when opened.  
- On iOS (VoiceOver), users can dismiss the popover using the "Escape" gesture (two-finger scrub).  
- On Android (TalkBack), users can dismiss it with a two-finger swipe down or the back gesture.  

This ensures consistent and expected accessibility behavior across platforms.